### PR TITLE
Initial background process greeting

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -25,24 +25,16 @@ const isPublicRoute = createRouteMatcher([
 ])
 
 export default clerkMiddleware(async (auth, req) => {
-  // Allow access to public routes
-  const publicRoutes = ['/'];
-  
-  if (publicRoutes.includes(req.nextUrl.pathname)) {
+  // Allow access to public routes without authentication
+  if (isPublicRoute(req)) {
     return;
   }
 
-  // Handle API routes
-  if (req.nextUrl.pathname.startsWith('/api/')) {
-    const { userId } = await auth();
-    if (!userId) {
-      return new Response('Unauthorized', { status: 401 });
-    }
-    return;
+  // For protected routes, require authentication
+  if (isProtectedRoute(req)) {
+    await auth.protect();
   }
 
-  // Protect all other routes
-  await auth.protect();
   return;
 });
 


### PR DESCRIPTION
Fix middleware logic to resolve an infinite redirect loop.

The previous middleware configuration caused a redirect loop by not correctly identifying public routes (like `/sign-in` and `/sign-up`) and applying `auth.protect()` too broadly, including on the sign-in page itself, leading to an infinite redirect. This PR correctly utilizes `isPublicRoute` and `isProtectedRoute` matchers to ensure proper authentication flow.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-d58d620f-eb4d-4d2f-8fd5-066c86b1e15e) · [Cursor](https://cursor.com/background-agent?bcId=bc-d58d620f-eb4d-4d2f-8fd5-066c86b1e15e)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)